### PR TITLE
Add parent constructor call

### DIFF
--- a/src/OroCRM/Bundle/CaseBundle/Entity/CaseEntity.php
+++ b/src/OroCRM/Bundle/CaseBundle/Entity/CaseEntity.php
@@ -302,6 +302,8 @@ class CaseEntity extends ExtendCaseEntity implements Taggable, EmailHolderInterf
     public function __construct()
     {
         $this->comments = new ArrayCollection();
+        
+        parent::__construct();
     }
 
     /**


### PR DESCRIPTION
According to https://github.com/ishakuta/crm/blob/master/src/OroCRM/Bundle/CaseBundle/Model/ExtendCaseEntity.php#L12
and how entity extend works, 
it's required to call parent constructor in entities, if they have it's own.